### PR TITLE
Add useArgumentFile option to help with Command line is too long error

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@
 Alexander Torstling (atorstling) <alexander@torstling.com>
 Andrey Batalev <andrey.batalev@gmail.com>
 Brice Figureau (masterzen) <brice@daysofwonder.com>
+Chris Heisterkamp (cheister) <cheister@squareup.com>
 Daniel Evans (devans) <daniel.evans@plymouthsystems.com> <devans@greenenergycorp.com>
 David Trott (dtrott) <github@davidtrott.com>
 Gregory Kick <gak@google.com>

--- a/src/it/TEST-25/pom.xml
+++ b/src/it/TEST-25/pom.xml
@@ -33,6 +33,10 @@
 
     <name>Integration Test 25</name>
 
+    <properties>
+        <protobufVersion>3.4.0</protobufVersion>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -45,7 +49,7 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <protocArtifact>com.google.protobuf:protoc:3.4.0:exe:${os.detected.classifier}
+                            <protocArtifact>com.google.protobuf:protoc:${protobufVersion}:exe:${os.detected.classifier}
                             </protocArtifact>
                         </configuration>
                     </execution>

--- a/src/it/TEST-29/invoker.properties
+++ b/src/it/TEST-29/invoker.properties
@@ -15,9 +15,8 @@
 #
 
 # An optional description for this build job to be included in the build reports.
-invoker.description = \
-  Verifies that useArgumentFile option compiles protos
+invoker.description = Verifies that protoc can be invoked with an @args file and that unicode file names are properly handled.
 
 # A comma or space separated list of goals/phases to execute, may
 # specify an empty list to execute the default goal of the IT project
-invoker.goals = clean compile
+invoker.goals = clean generate-sources

--- a/src/it/TEST-29/invoker.properties
+++ b/src/it/TEST-29/invoker.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# An optional description for this build job to be included in the build reports.
+invoker.description = \
+  Verifies that useArgumentFile option compiles protos
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean compile

--- a/src/it/TEST-29/pom.xml
+++ b/src/it/TEST-29/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.xolstice.maven.plugins.protobuf.its</groupId>
+        <artifactId>it-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>test-29</artifactId>
+    <version>1.0.0</version>
+
+    <name>Integration Test 29</name>
+
+    <properties>
+        <protobufVersion>3.5.0</protobufVersion>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>protobuf-toolchain</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                        <configuration>
+                            <toolchains>
+                                <protobuf>
+                                    <version>${protobufVersion}</version>
+                                </protobuf>
+                            </toolchains>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <useArgumentFile>true</useArgumentFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/TEST-29/pom.xml
+++ b/src/it/TEST-29/pom.xml
@@ -34,44 +34,26 @@
     <name>Integration Test 29</name>
 
     <properties>
-        <protobufVersion>3.5.0</protobufVersion>
+        <!--  @args files are supported by protoc starting with version 3.5.0 -->
+        <protobufVersion>3.5.1</protobufVersion>
     </properties>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-toolchains-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>protobuf-toolchain</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>toolchain</goal>
-                        </goals>
-                        <configuration>
-                            <toolchains>
-                                <protobuf>
-                                    <version>${protobufVersion}</version>
-                                </protobuf>
-                            </toolchains>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>@project.version@</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <useArgumentFile>true</useArgumentFile>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:${protobufVersion}:exe:${os.detected.classifier}
+                            </protocArtifact>
+                            <useArgumentFile>true</useArgumentFile>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/it/TEST-29/src/main/proto/test.proto
+++ b/src/it/TEST-29/src/main/proto/test.proto
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+option java_package = "test";
+option java_outer_classname = "TestProtos";
+option optimize_for = SPEED;
+
+message TestMessage {
+  message NestedMessage {
+    optional int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 1;
+    BAR = 2;
+    BAZ = 3;
+  }
+
+  // Singular
+  optional    int32 optional_int32    =  1;
+}

--- a/src/it/TEST-29/src/main/proto/test.proto
+++ b/src/it/TEST-29/src/main/proto/test.proto
@@ -14,21 +14,11 @@
 // limitations under the License.
 //
 
+syntax = "proto3";
+
 option java_package = "test";
 option java_outer_classname = "TestProtos";
 option optimize_for = SPEED;
 
 message TestMessage {
-  message NestedMessage {
-    optional int32 bb = 1;
-  }
-
-  enum NestedEnum {
-    FOO = 1;
-    BAR = 2;
-    BAZ = 3;
-  }
-
-  // Singular
-  optional    int32 optional_int32    =  1;
 }

--- a/src/it/TEST-29/src/main/proto/тест.proto
+++ b/src/it/TEST-29/src/main/proto/тест.proto
@@ -17,8 +17,8 @@
 syntax = "proto3";
 
 option java_package = "test";
-option java_outer_classname = "TestProtos";
+option java_outer_classname = "TestProtosRu";
 option optimize_for = SPEED;
 
-message TestMessage {
+message TestMessageRu {
 }

--- a/src/it/TEST-29/src/main/proto/テスト.proto
+++ b/src/it/TEST-29/src/main/proto/テスト.proto
@@ -17,8 +17,8 @@
 syntax = "proto3";
 
 option java_package = "test";
-option java_outer_classname = "TestProtos";
+option java_outer_classname = "TestProtosJp";
 option optimize_for = SPEED;
 
-message TestMessage {
+message TestMessageJp {
 }

--- a/src/it/TEST-29/verify.groovy
+++ b/src/it/TEST-29/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+outputDirectory = new File(basedir, 'target/generated-sources/protobuf/java');
+assert outputDirectory.exists();
+assert outputDirectory.isDirectory();
+
+generatedJavaFile = new File(outputDirectory, 'test/TestProtos.java');
+assert generatedJavaFile.exists();
+assert generatedJavaFile.isFile();
+
+content = generatedJavaFile.text;
+assert content.contains('package test');
+assert content.contains('class Test');
+assert content.contains('class TestMessage');
+
+return true;

--- a/src/it/TEST-29/verify.groovy
+++ b/src/it/TEST-29/verify.groovy
@@ -24,7 +24,25 @@ assert generatedJavaFile.isFile();
 
 content = generatedJavaFile.text;
 assert content.contains('package test');
-assert content.contains('class Test');
+assert content.contains('class TestProtos');
 assert content.contains('class TestMessage');
+
+generatedJavaFile = new File(outputDirectory, 'test/TestProtosJp.java');
+assert generatedJavaFile.exists();
+assert generatedJavaFile.isFile();
+
+content = generatedJavaFile.text;
+assert content.contains('package test');
+assert content.contains('class TestProtosJp');
+assert content.contains('class TestMessageJp');
+
+generatedJavaFile = new File(outputDirectory, 'test/TestProtosRu.java');
+assert generatedJavaFile.exists();
+assert generatedJavaFile.isFile();
+
+content = generatedJavaFile.text;
+assert content.contains('package test');
+assert content.contains('class TestProtosRu');
+assert content.contains('class TestMessageRu');
 
 return true;

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -346,6 +346,19 @@ abstract class AbstractProtocMojo extends AbstractMojo {
     protected boolean includeSourceInfoInDescriptorSet;
 
     /**
+     * If set to {@code true}, the arguments to protoc will be put in a file and run as an argument
+     * file.  This is helpful if you are getting Command line is too long errors
+     * This is only supported for protoc 3.5.0 and higher
+     *
+     * @since 0.6.0
+     */
+    @Parameter(
+        required = false,
+        defaultValue = "false"
+    )
+    protected boolean useArgumentFile;
+
+    /**
      * Specifies one of more custom protoc plugins, written in Java
      * and available as Maven artifacts. An executable plugin will be created
      * at execution time. On UNIX the executable is a shell script and on
@@ -661,6 +674,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                     includeDependenciesInDescriptorSet,
                     includeSourceInfoInDescriptorSet);
         }
+        protocBuilder.useArgumentFile(useArgumentFile);
     }
 
     /**

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -174,6 +174,18 @@ abstract class AbstractProtocMojo extends AbstractMojo {
     private List<ArtifactRepository> remoteRepositories;
 
     /**
+     * A directory where temporary files will be generated.
+     *
+     * @since 0.6.0
+     */
+    @Parameter(
+            required = true,
+            readonly = true,
+            defaultValue = "${project.build.directory}"
+    )
+    private File tempDirectory;
+
+    /**
      * A directory where native launchers for java protoc plugins will be generated.
      *
      * @since 0.3.0
@@ -674,6 +686,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                     includeDependenciesInDescriptorSet,
                     includeSourceInfoInDescriptorSet);
         }
+        protocBuilder.setTempDirectory(tempDirectory);
         protocBuilder.useArgumentFile(useArgumentFile);
     }
 

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -353,8 +353,8 @@ abstract class AbstractProtocMojo extends AbstractMojo {
      * @since 0.6.0
      */
     @Parameter(
-        required = false,
-        defaultValue = "false"
+            required = false,
+            defaultValue = "false"
     )
     protected boolean useArgumentFile;
 


### PR DESCRIPTION
This is primarily to address https://github.com/xolstice/protobuf-maven-plugin/issues/5

I've only tested it on OSX and Linux.  I don't have a Windows setup to test with.

A nicer option might be to detect if protoc is 3.5.0 or higher and then automatically put the args in the argumentFile but I wasn't sure how to get the protoc version in a nice way. 