### PR TITLE
Require minimum Java 8 and Maven 3.3.9

### DIFF
--- a/.appveyor/toolchains.xml
+++ b/.appveyor/toolchains.xml
@@ -29,17 +29,6 @@
         </configuration>
     </toolchain>
     <toolchain>
-        <type>jdk</type>
-        <provides>
-            <version>1.6</version>
-            <vendor>OpenJDK</vendor>
-            <id>openjdk6</id>
-        </provides>
-        <configuration>
-            <jdkHome>C:/Program Files/Java/jdk1.6.0</jdkHome>
-        </configuration>
-    </toolchain>
-    <toolchain>
         <type>protobuf</type>
         <provides>
             <version>3.4.0</version>

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ dist: trusty
 sudo: false
 
 language: java
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
 jdk: openjdk8
 
 before_install:

--- a/.travis/toolchains.xml
+++ b/.travis/toolchains.xml
@@ -29,17 +29,6 @@
         </configuration>
     </toolchain>
     <toolchain>
-        <type>jdk</type>
-        <provides>
-            <version>1.6</version>
-            <vendor>OpenJDK</vendor>
-            <id>openjdk6</id>
-        </provides>
-        <configuration>
-            <jdkHome>/usr/lib/jvm/java-6-openjdk-amd64</jdkHome>
-        </configuration>
-    </toolchain>
-    <toolchain>
         <type>protobuf</type>
         <provides>
             <version>3.4.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,16 +33,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JDK version -->
-        <java.sdk.version>1.6</java.sdk.version>
+        <java.sdk.version>1.8</java.sdk.version>
         <!-- Settings for the java compiler -->
         <java.compiler.compilerVersion>${java.sdk.version}</java.compiler.compilerVersion>
         <java.compiler.source>${java.sdk.version}</java.compiler.source>
         <java.compiler.target>${java.sdk.version}</java.compiler.target>
 
-        <mavenVersion>3.0</mavenVersion>
+        <mavenVersion>3.3.9</mavenVersion>
         <plexusComponentVersion>1.7.1</plexusComponentVersion>
-        <plexusUtilsVersion>3.1.0</plexusUtilsVersion>
-        <pluginToolsVersion>3.5.2</pluginToolsVersion>
+        <plexusUtilsVersion>3.1.1</plexusUtilsVersion>
+        <pluginToolsVersion>3.6.0</pluginToolsVersion>
 
         <goalPrefix>protobuf</goalPrefix>
     </properties>
@@ -111,6 +111,12 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0-M2</version>
                 </plugin>
@@ -124,7 +130,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.6.0</version>
                 </plugin>
 
                 <plugin>
@@ -148,7 +154,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>3.0.0-M3</version>
                 </plugin>
 
                 <plugin>
@@ -166,7 +172,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
 
                 <plugin>
@@ -202,6 +208,12 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                 </plugin>
@@ -209,7 +221,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
 
             </plugins>
@@ -456,7 +468,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.6.0</version>
                 <configuration>
                     <mojoDependencies />
                     <goalPrefix>${goalPrefix}</goalPrefix>
@@ -613,18 +625,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <configuration>
-                            <!--
-                                Explicitly disable updating the release metadata in the remote repository,
-                                because otherwise that messes BinTray repository layout up.
-                                BinTray itself takes care of metadata when the artifacts are promoted.
-                            -->
-                            <updateReleaseInfo>false</updateReleaseInfo>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -650,6 +650,12 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>${pluginToolsVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -684,6 +690,10 @@
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>plexus-utils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,9 @@
     <body>
 
         <release version="0.7.0" date="Pending" description="TBD">
+            <action dev="sergei-ivanov" type="update" issue="49">
+                Java 1.8 and Maven 3.3.9 are now minimum required versions for running the plugin.
+            </action>
             <action dev="sergei-ivanov" type="update" issue="47" due-to="Cosmin Lehene (clehene)">
                 More detailed error message.
             </action>

--- a/src/it/dependencies/pom.xml
+++ b/src/it/dependencies/pom.xml
@@ -68,12 +68,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>3.0.0-M3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/setup-it-parent/pom.xml
+++ b/src/it/setup-it-parent/pom.xml
@@ -33,13 +33,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JDK version -->
-        <java.sdk.version>1.6</java.sdk.version>
+        <java.sdk.version>1.8</java.sdk.version>
         <!-- Settings for the java compiler -->
         <java.compiler.compilerVersion>${java.sdk.version}</java.compiler.compilerVersion>
         <java.compiler.source>${java.sdk.version}</java.compiler.source>
         <java.compiler.target>${java.sdk.version}</java.compiler.target>
 
-        <mavenVersion>3.0</mavenVersion>
+        <mavenVersion>3.3.9</mavenVersion>
 
         <protobufVersion>3.6.1</protobufVersion>
     </properties>
@@ -82,13 +82,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>3.0.0-M3</version>
                     <inherited>true</inherited>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                     <inherited>true</inherited>
                 </plugin>
                 <plugin>

--- a/src/it/setup-protoc-plugin/pom.xml
+++ b/src/it/setup-protoc-plugin/pom.xml
@@ -33,7 +33,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JDK version -->
-        <java.sdk.version>1.6</java.sdk.version>
+        <java.sdk.version>1.8</java.sdk.version>
         <!-- Settings for the java compiler -->
         <java.compiler.compilerVersion>${java.sdk.version}</java.compiler.compilerVersion>
         <java.compiler.source>${java.sdk.version}</java.compiler.source>
@@ -71,7 +71,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -870,7 +870,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
         if (dependencyArtifacts.isEmpty()) {
             return emptyList();
         }
-        final List<File> dependencyArtifactFiles = new ArrayList<File>(dependencyArtifacts.size());
+        final List<File> dependencyArtifactFiles = new ArrayList<>(dependencyArtifacts.size());
         for (final Artifact artifact : dependencyArtifacts) {
             dependencyArtifactFiles.add(artifact.getFile());
         }
@@ -904,7 +904,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                 throw new MojoInitializationException("Unable to clean up temporary proto file directory", e);
             }
         }
-        final List<File> protoDirectories = new ArrayList<File>();
+        final List<File> protoDirectories = new ArrayList<>();
         for (final File classpathElementFile : classpathElementFiles) {
             // for some reason under IAM, we receive poms as dependent files
             // I am excluding .xml rather than including .jar as there may be other extensions in use (sar, har, zip)
@@ -986,7 +986,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
         if (directories == null) {
             throw new MojoConfigurationException("'directories' is null");
         }
-        final List<File> protoFiles = new ArrayList<File>();
+        final List<File> protoFiles = new ArrayList<>();
         for (final File directory : directories) {
             protoFiles.addAll(findProtoFilesInDirectory(directory));
         }

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
@@ -258,7 +258,7 @@ final class Protoc {
      * @return A list consisting of the executable followed by any arguments.
      */
     public List<String> buildProtocCommand() {
-        final List<String> command = new ArrayList<String>();
+        final List<String> command = new ArrayList<>();
         // add the executable
         for (final File protoPathElement : protoPathElements) {
             command.add("--proto_path=" + protoPathElement);
@@ -433,7 +433,7 @@ final class Protoc {
      * @return the temporary file wth the arguments
      * @throws IOException
      */
-    private File createFileWithArguments(String[] args) throws IOException {
+    private File createFileWithArguments(String... args) throws IOException {
         PrintWriter writer = null;
         try {
             final File tempFile = File.createTempFile("protoc", null, tempDirectory);
@@ -536,9 +536,9 @@ final class Protoc {
                 throw new MojoConfigurationException("'executable' is null");
             }
             this.executable = executable;
-            protoFiles = new ArrayList<File>();
-            protopathElements = new LinkedHashSet<File>();
-            plugins = new ArrayList<ProtocPlugin>();
+            protoFiles = new ArrayList<>();
+            protopathElements = new LinkedHashSet<>();
+            plugins = new ArrayList<>();
         }
 
         public Builder setTempDirectory(final File tempDirectory) {
@@ -888,7 +888,7 @@ final class Protoc {
             validateState();
             return new Protoc(
                     executable,
-                    new ArrayList<File>(protopathElements),
+                    new ArrayList<>(protopathElements),
                     protoFiles,
                     javaOutputDirectory,
                     javaNanoOutputDirectory,

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
@@ -20,8 +20,9 @@ import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.Os;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
+
+import static java.util.Collections.emptyList;
 
 /**
  * Describes a {@code protoc} plugin that is written in Java and
@@ -123,7 +124,7 @@ public class ProtocPlugin {
      * @return a list of command-line arguments.
      */
     public List<String> getArgs() {
-        return (args != null) ? args : Collections.<String>emptyList();
+        return args != null ? args : emptyList();
     }
 
     /**
@@ -132,7 +133,7 @@ public class ProtocPlugin {
      * @return a list of JVM options.
      */
     public List<String> getJvmArgs() {
-        return (jvmArgs != null) ? jvmArgs : Collections.<String>emptyList();
+        return jvmArgs != null ? jvmArgs : emptyList();
     }
 
     public String getJavaHome() {

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPluginAssembler.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPluginAssembler.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Collections.emptyMap;
+
 /**
  * Creates an executable {@code protoc} plugin (written in Java) from a {@link ProtocPlugin} specification.
  *
@@ -66,7 +68,7 @@ public class ProtocPluginAssembler {
 
     private final File pluginDirectory;
 
-    private final List<File> resolvedJars = new ArrayList<File>();
+    private final List<File> resolvedJars = new ArrayList<>();
 
     private final File pluginExecutableFile;
 
@@ -136,9 +138,7 @@ public class ProtocPluginAssembler {
             log.debug("winJvmDataModel=" + pluginDefinition.getWinJvmDataModel());
         }
 
-        PrintWriter out = null;
-        try {
-            out = new PrintWriter(new FileWriter(winRun4JIniFile));
+        try (final PrintWriter out = new PrintWriter(new FileWriter(winRun4JIniFile))) {
             if (jvmLocation != null) {
                 out.println("vm.location=" + jvmLocation.getAbsolutePath());
             }
@@ -161,7 +161,7 @@ public class ProtocPluginAssembler {
                 index++;
             }
 
-            out.println("vm.version.min=1.6");
+            out.println("vm.version.min=1.8");
 
             // keep from logging to stdout (the default)
             out.println("log.level=none");
@@ -170,10 +170,6 @@ public class ProtocPluginAssembler {
         } catch (IOException e) {
             throw new MojoInitializationException(
                     "Could not write WinRun4J ini file: " + winRun4JIniFile.getAbsolutePath(), e);
-        } finally {
-            if (out != null) {
-                out.close();
-            }
         }
     }
 
@@ -211,9 +207,7 @@ public class ProtocPluginAssembler {
             log.debug("javaLocation=" + javaLocation.getAbsolutePath());
         }
 
-        PrintWriter out = null;
-        try {
-            out = new PrintWriter(new FileWriter(pluginExecutableFile));
+        try (final PrintWriter out = new PrintWriter(new FileWriter(pluginExecutableFile))) {
             out.println("#!/bin/sh");
             out.println();
             out.print("CP=");
@@ -240,10 +234,6 @@ public class ProtocPluginAssembler {
             out.println();
         } catch (IOException e) {
             throw new MojoInitializationException("Could not write plugin script file: " + pluginExecutableFile, e);
-        } finally {
-            if (out != null) {
-                out.close();
-            }
         }
     }
 
@@ -276,7 +266,7 @@ public class ProtocPluginAssembler {
                 .setArtifact(rootResolutionArtifact)
                 .setResolveRoot(false)
                 .setArtifactDependencies(Collections.singleton(protocPluginArtifact))
-                .setManagedVersionMap(Collections.emptyMap())
+                .setManagedVersionMap(emptyMap())
                 .setLocalRepository(localRepository)
                 .setRemoteRepositories(remoteRepositories)
                 .setOffline(session.isOffline())

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -61,8 +61,8 @@ Usage
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -99,11 +99,9 @@ Usage
 
   The following conditions need to be met:
 
-  * Java 1.5 or newer is required due to the usage of Generics
+  * Java 1.8 or newer is required for running Maven
 
-  * Java 1.6 or newer is required for running custom Java plugins for protobuf compiler
-
-  * Java 1.7 or newer is recommended
+  * Java 1.8 or newer is required for compiling the generated sources
 
   * Either <<<protoc>>> executable has to be in the <<<PATH>>> or
     the <<<protocExecutable>>> parameter has to be set to the correct location.
@@ -156,7 +154,7 @@ mvn clean install
   Unfortunately, for versions of <<<protoc>>> below 3.5.0, the only available option is to split
   the compilation into smaller chunks by decomposing the project into modules.
 
-* Compiling Protobuf Sources into C++ or Python
+* Compiling Protobuf Sources into other programming languages
 
   The plugin configuration is similar to compiling into Java, with the following alterations:
 


### PR DESCRIPTION
**Applicable Issues**

Fixes #49

**Description**

* Java 8 or later is required to build and run the plugin
* Java 8 or later is required to run the integration tests
* Maven 3.3.9 or later is required to run the plugin
* Updated Maven plugins and dependencies to the latest version
* Removed reflection-based workaround to support Maven 3.2 and earlier
* Cleaned up the code for Java 8
* Cleaned up CI configuration and toolchains