### PR TITLE
Use pb instead of protobin for binary descriptors

### DIFF
--- a/src/it/TEST-15/verify.groovy
+++ b/src/it/TEST-15/verify.groovy
@@ -18,7 +18,7 @@ outputDirectory = new File(basedir, 'target/generated-resources/protobuf/descrip
 assert outputDirectory.exists();
 assert outputDirectory.isDirectory();
 
-generatedJavaFile = new File(outputDirectory, 'test-15-1.0.0.protobin');
+generatedJavaFile = new File(outputDirectory, 'test-15-1.0.0.pb');
 assert generatedJavaFile.exists();
 assert generatedJavaFile.isFile();
 

--- a/src/it/TEST-24/project2/pom.xml
+++ b/src/it/TEST-24/project2/pom.xml
@@ -46,7 +46,7 @@
                         <configuration>
                             <includeGroupIds>${project.groupId}</includeGroupIds>
                             <includeArtifactIds>test-24-project1</includeArtifactIds>
-                            <includeTypes>protobin</includeTypes>
+                            <includeTypes>pb</includeTypes>
                         </configuration>
                     </execution>
                 </executions>
@@ -59,7 +59,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>test-24-project1</artifactId>
             <version>1.0.0</version>
-            <type>protobin</type>
+            <type>pb</type>
         </dependency>
     </dependencies>
 </project>

--- a/src/it/TEST-24/verify.groovy
+++ b/src/it/TEST-24/verify.groovy
@@ -18,7 +18,7 @@ outputDirectory = new File(basedir, 'project2/target/dependency');
 assert outputDirectory.exists();
 assert outputDirectory.isDirectory();
 
-generatedJavaFile = new File(outputDirectory, 'test-24-project1-1.0.0.protobin');
+generatedJavaFile = new File(outputDirectory, 'test-24-project1-1.0.0.pb');
 assert generatedJavaFile.exists();
 assert generatedJavaFile.isFile();
 

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocCompileMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocCompileMojo.java
@@ -73,7 +73,7 @@ public abstract class AbstractProtocCompileMojo extends AbstractProtocMojo {
         project.addCompileSourceRoot(outputDirectory.getAbsolutePath());
         if (writeDescriptorSet) {
             final File descriptorSetFile = new File(getDescriptorSetOutputDirectory(), descriptorSetFileName);
-            projectHelper.attachArtifact(project, "protobin", descriptorSetClassifier, descriptorSetFile);
+            projectHelper.attachArtifact(project, "pb", descriptorSetClassifier, descriptorSetFile);
         }
         buildContext.refresh(outputDirectory);
     }

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -304,7 +304,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
      */
     @Parameter(
             required = true,
-            defaultValue = "${project.build.finalName}.protobin"
+            defaultValue = "${project.build.finalName}.pb"
     )
     protected String descriptorSetFileName;
 

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocTestCompileMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocTestCompileMojo.java
@@ -74,7 +74,7 @@ public abstract class AbstractProtocTestCompileMojo extends AbstractProtocMojo {
         project.addTestCompileSourceRoot(outputDirectory.getAbsolutePath());
         if (writeDescriptorSet) {
             final File descriptorSetFile = new File(getDescriptorSetOutputDirectory(), descriptorSetFileName);
-            projectHelper.attachArtifact(project, "test-protobin", descriptorSetClassifier, descriptorSetFile);
+            projectHelper.attachArtifact(project, "test-pb", descriptorSetClassifier, descriptorSetFile);
         }
         buildContext.refresh(outputDirectory);
     }

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -20,25 +20,25 @@
     <components>
         <component>
             <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-            <role-hint>protobin</role-hint>
+            <role-hint>pb</role-hint>
             <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
             <configuration>
-                <extension>protobin</extension>
-                <type>protobin</type>
-                <packaging>protobin</packaging>
+                <extension>pb</extension>
+                <type>pb</type>
+                <packaging>pb</packaging>
                 <language>protobuf</language>
                 <addedToClasspath>false</addedToClasspath>
             </configuration>
         </component>
         <component>
             <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-            <role-hint>test-protobin</role-hint>
+            <role-hint>test-pb</role-hint>
             <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
             <configuration>
                 <classifier>test</classifier>
-                <extension>protobin</extension>
-                <type>test-protobin</type>
-                <packaging>protobin</packaging>
+                <extension>pb</extension>
+                <type>test-pb</type>
+                <packaging>pb</packaging>
                 <language>protobuf</language>
                 <addedToClasspath>false</addedToClasspath>
             </configuration>

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -232,7 +232,7 @@ mvn toolchains:toolchain ${goalPrefix}:test-compile
   and <<<--include_imports>>> arguments to <<<protoc>>>.
 
   Generated descriptor sets can optionally be attached to the build as artifacts.
-  The default type and extension for descriptor sets is <<<protobin>>>, and the plugin extensions need
+  The default type and extension for descriptor sets is <<<pb>>>, and the plugin extensions need
   to be enabled in order to support the correct resolution of those dependencies in downstream projects.
 
   The following plugin options configure descriptor set output:
@@ -247,7 +247,7 @@ mvn toolchains:toolchain ${goalPrefix}:test-compile
     if this option is enabled.
 
   * <<<descriptorSetFileName>>> - the file name of the descriptor set; default is the artifact name with
-    the <<<.protobin>>> extension.
+    the <<<.pb>>> extension.
 
   * <<<descriptorSetOutputDirectory>>> - the directory where the descriptor set file will be created
 


### PR DESCRIPTION
**Description**
gcloud endpoints currently expects  `['.pb', '.descriptor', '.proto.bin']` extensions or otherwise will fail with 

```
UnicodeDecodeError: 'utf8' codec can't decode byte 0xae in position 1: invalid start byte
ERROR: gcloud crashed (UnicodeDecodeError): 'utf8' codec can't decode byte 0xae in position 1: invalid start byte
```
I've spent hours trying to figure how the file gets 'corrupted'..

I've also made a PR to look at the mime-type but it would probably be best to go with the "more default" extensions for descriptors.
https://github.com/google-cloud-sdk/google-cloud-sdk/pull/4

