### PR TITLE
Attempting to correct descriptor attach bug

### DIFF
--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocCompileDescriptorSetMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocCompileDescriptorSetMojo.java
@@ -114,9 +114,11 @@ public final class ProtocCompileDescriptorSetMojo extends AbstractProtocCompileM
     @SuppressWarnings("MethodDoesntCallSuperMethod")
     @Override
     protected void doAttachGeneratedFiles() {
-        final File outputDirectory = getOutputDirectory();
-        final File descriptorSetFile = new File(getOutputDirectory(), descriptorSetFileName);
-        projectHelper.attachArtifact(project, "pb", classifier, descriptorSetFile);
-        buildContext.refresh(outputDirectory);
+        if (attach) {
+            final File outputDirectory = getOutputDirectory();
+            final File descriptorSetFile = new File(getOutputDirectory(), descriptorSetFileName);
+            projectHelper.attachArtifact(project, "pb", classifier, descriptorSetFile);
+            buildContext.refresh(outputDirectory);
+        }
     }
 }


### PR DESCRIPTION
Descriptors are attached to the build regardless of whether
attachDescriptorSet is set or not.

**Applicable Issues**

**Description**
Descriptor sets are attached to the build regardless of what <attachDescriptorSet> is set to.
