### PR TITLE
the import files of the proto file will be code generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>protobuf-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>Maven Protocol Buffers Plugin</name>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <url>https://www.xolstice.org/protobuf-maven-plugin</url>
     <description>Maven Plugin that executes the Protocol Buffers (protoc) compiler</description>
     <inceptionYear>2016</inceptionYear>

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -603,7 +603,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
     protected boolean checkProtoFile(File fileProto) {
         if (skipFiles != null && skipFiles.size() > 0) {
             for (String file : skipFiles) {
-                if (fileProto.getAbsolutePath().endsWith(file)) {
+                if (fileProto.getAbsolutePath().endsWith("/"+file)) {
                     getLog().debug("skipping the file: " + fileProto.getAbsolutePath() + ", because skipped file is " + file);
                     return false;
                 }

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -413,7 +413,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
      */
     @Parameter(
             required = false,
-            defaultValue = "any.proto,descriptor.proto,empty.proto,struct.proto"
+            defaultValue = ""
     )
     private List<String>skipFiles;
 
@@ -601,10 +601,12 @@ abstract class AbstractProtocMojo extends AbstractMojo {
     }
 
     protected boolean checkProtoFile(File fileProto) {
-        for (String file : skipFiles) {
-            if (fileProto.getAbsolutePath().endsWith(file)){
-                getLog().debug("skipping the file: "+fileProto.getAbsolutePath()+", because skipped file is "+file);
-                return false;
+        if (skipFiles != null && skipFiles.size() > 0) {
+            for (String file : skipFiles) {
+                if (fileProto.getAbsolutePath().endsWith(file)) {
+                    getLog().debug("skipping the file: " + fileProto.getAbsolutePath() + ", because skipped file is " + file);
+                    return false;
+                }
             }
         }
         return true;

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -437,12 +437,13 @@ abstract class AbstractProtocMojo extends AbstractMojo {
         final File protoSourceRoot = getProtoSourceRoot();
         if (protoSourceRoot.exists()) {
             try {
-                final List<File> protoFiles = findProtoFilesInDirectory(protoSourceRoot);
+                List<File> protoFiles = findProtoFilesInDirectory(protoSourceRoot);
                 if (generateImport) {
                     getLog().debug("Find: " + protoFiles);
                     Set<File> importFiles = getDependencyProto(protoFiles, protoSourceRoot);
                     getLog().debug("IMPORT FILE: " + importFiles);
-                    protoFiles.addAll(importFiles);
+                    importFiles.addAll(new HashSet<>(protoFiles));
+                    protoFiles=new ArrayList<>(importFiles);
                 }
                 getLog().debug("ALL PROTO: "+protoFiles);
                 final File outputDirectory = getOutputDirectory();

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -584,6 +584,15 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                 if (matcher.find()) {
                     String protoFile = matcher.group(1);
                     File fileProto = new File(protoSourceRoot, protoFile);
+                    if (!fileProto.exists() && additionalProtoPathElements != null && additionalProtoPathElements.length > 0) {
+                        for (File element : additionalProtoPathElements) {
+                            fileProto = new File(element, protoFile);
+                            if (fileProto.exists()){
+                                break;
+                            }
+                        }
+                    }
+
                     if (!fileProto.exists()){
                         getLog().error("NO FIND IMPORT FILE: "+fileProto.getAbsolutePath());
                     }


### PR DESCRIPTION
the import files of the proto file can be code generation as well if there is some import file in the proto file .  So, we add a parameter "generateImport"

the plugin is config like below:
```
<plugin>
                <groupId>org.xolstice.maven.plugins</groupId>
                <artifactId>protobuf-maven-plugin</artifactId>
                <configuration>
                    <generateImport>true</generateImport>
                    <protoSourceRoot>${proto.source.root}</protoSourceRoot>
                    <includes>
                        ${proto}
                    </includes>
                    <outputDirectory>${project.basedir}/src/main/java</outputDirectory>
                    <clearOutputDirectory>false</clearOutputDirectory>
                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                    <pluginId>grpc-java</pluginId>
                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${protoc-gen-grpc-java.version}:exe:${os.detected.classifier}</pluginArtifact>
                </configuration>
                <executions>
                    <execution>
                        <goals>
                            <goal>compile</goal>
                            <goal>compile-custom</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
```
