### PR TITLE
Allow ProtoPlugin to specify an executable artifact that does not need to be run by Java

### DIFF
--- a/src/it/TEST-16/pom.xml
+++ b/src/it/TEST-16/pom.xml
@@ -39,6 +39,13 @@
     </properties>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
@@ -69,6 +76,14 @@
                                     <args>
                                         <arg>prefix-</arg>
                                     </args>
+                                </protocPlugin>
+                                <protocPlugin>
+                                    <id>grpc-java</id>
+                                    <groupId>io.grpc</groupId>
+                                    <artifactId>protoc-gen-grpc-java</artifactId>
+                                    <version>1.12.0</version>
+                                    <type>exe</type>
+                                    <classifier>${os.detected.classifier}</classifier>
                                 </protocPlugin>
                             </protocPlugins>
                         </configuration>

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -540,16 +540,23 @@ abstract class AbstractProtocMojo extends AbstractMojo {
         final String javaHome = detectJavaHome();
 
         for (final ProtocPlugin plugin : protocPlugins) {
-
-            if (plugin.getJavaHome() != null) {
-                getLog().debug("Using javaHome defined in plugin definition: " + plugin.getJavaHome());
-            } else {
-                getLog().debug("Setting javaHome for plugin: " + javaHome);
-                plugin.setJavaHome(javaHome);
-            }
-
             getLog().info("Building protoc plugin: " + plugin.getId());
-            final ProtocPluginAssembler assembler = new ProtocPluginAssembler(
+
+            if (plugin.getMainClass() == null) {
+                final Artifact pluginArtifact = createDependencyArtifact(plugin.getGroupId(), plugin.getArtifactId(),
+                    plugin.getVersion(), plugin.getType(), plugin.getClassifier());
+                final File file = resolveBinaryArtifact(pluginArtifact);
+                getLog().debug("Setting executableFile for plugin: " + file.getAbsolutePath());
+                plugin.setExecutableFile(file);
+            } else {
+                if (plugin.getJavaHome() != null) {
+                    getLog().debug("Using javaHome defined in plugin definition: " + plugin.getJavaHome());
+                } else {
+                    getLog().debug("Setting javaHome for plugin: " + javaHome);
+                    plugin.setJavaHome(javaHome);
+                }
+
+                final ProtocPluginAssembler assembler = new ProtocPluginAssembler(
                     plugin,
                     session,
                     project.getArtifact(),
@@ -560,7 +567,8 @@ abstract class AbstractProtocMojo extends AbstractMojo {
                     remoteRepositories,
                     protocPluginDirectory,
                     getLog());
-            assembler.execute();
+                assembler.execute();
+            }
         }
     }
 

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
@@ -48,6 +48,8 @@ public class ProtocPlugin {
 
     private String version;
 
+    private String type;
+
     private String classifier;
 
     private String mainClass;
@@ -62,6 +64,8 @@ public class ProtocPlugin {
     private List<String> args;
 
     private List<String> jvmArgs;
+
+    private File executableFile;
 
     /**
      * Returns the unique id for this plugin.
@@ -98,6 +102,15 @@ public class ProtocPlugin {
      */
     public String getVersion() {
         return version;
+    }
+
+    /**
+     * Returns an optional type of the plugin's artifact for dependency resolution.
+     *
+     * @return the plugin's artifact type.
+     */
+    public String getType() {
+        return type;
     }
 
     /**
@@ -152,6 +165,10 @@ public class ProtocPlugin {
         return "protoc-gen-" + id;
     }
 
+    public void setExecutableFile(final File executableFile) {
+        this.executableFile = executableFile;
+    }
+
     /**
      * Validate the state of this plugin specification.
      *
@@ -169,9 +186,6 @@ public class ProtocPlugin {
         }
         if (version == null) {
             throw new MojoConfigurationException("version must be set in protocPlugin definition");
-        }
-        if (mainClass == null) {
-            throw new MojoConfigurationException("mainClass must be set in protocPlugin definition");
         }
         if (javaHome == null || !new File(javaHome).isDirectory()) {
             throw new MojoConfigurationException("javaHome is invalid: " + javaHome);
@@ -223,10 +237,14 @@ public class ProtocPlugin {
      * @return file handle for the plugin executable.
      */
     public File getPluginExecutableFile(final File pluginDirectory) {
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            return new File(pluginDirectory, getPluginName() + ".exe");
+        if (executableFile != null) {
+            return executableFile;
         } else {
-            return new File(pluginDirectory, getPluginName());
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                return new File(pluginDirectory, getPluginName() + ".exe");
+            } else {
+                return new File(pluginDirectory, getPluginName());
+            }
         }
     }
 
@@ -237,12 +255,14 @@ public class ProtocPlugin {
                 ", groupId='" + groupId + '\'' +
                 ", artifactId='" + artifactId + '\'' +
                 ", version='" + version + '\'' +
+                ", type='" + type + '\'' +
                 ", classifier='" + classifier + '\'' +
                 ", mainClass='" + mainClass + '\'' +
                 ", javaHome='" + javaHome + '\'' +
                 ", winJvmDataModel='" + winJvmDataModel + '\'' +
                 ", args=" + args +
                 ", jvmArgs=" + jvmArgs +
+                ", executableFile=" + executableFile +
                 '}';
     }
 }

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPluginAssembler.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPluginAssembler.java
@@ -258,7 +258,7 @@ public class ProtocPluginAssembler {
                         pluginDefinition.getGroupId(),
                         pluginDefinition.getArtifactId(),
                         versionSpec,
-                        "jar",
+                        pluginDefinition.getType() != null ? pluginDefinition.getType() : "jar",
                         pluginDefinition.getClassifier(),
                         Artifact.SCOPE_RUNTIME);
 


### PR DESCRIPTION
**Applicable Issues**
I didn't open an issue for this before creating the PR

**Description**
I want to be able to use proto plugins that are executables and not jars. e.g. java-grpc https://github.com/grpc/grpc-java/blob/master/README.md

I couldn't get the combination of protocPlugins and pluginArtifact with custom-compile to run consistently.  

Currently all protocPlugins are assumed to be jar classes that need to be run with java.  java-grpc is a standalone executable plugin so I added the option for the following to work.

```
            <protocPlugin>
              <id>grpc-java</id>
              <groupId>io.grpc</groupId>
              <artifactId>protoc-gen-grpc-java</artifactId>
              <version>1.12.0</version>
              <type>exe</type>
              <classifier>${os.detected.classifier}</classifier>
            </protocPlugin>
```

If no mainClass is specified then it is assumed the protocPlugin is an executable artifact and is downloaded and run.

I also wonder if this change might also eliminate the need for the pluginArtifact option? 