### PR TITLE
Allow for custom plugins to be supplied to the main invocation of pro…

### DIFF
--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocCompileMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocCompileMojo.java
@@ -62,4 +62,5 @@ public abstract class AbstractProtocCompileMojo extends AbstractProtocMojo {
     protected File getProtoSourceRoot() {
         return protoSourceRoot;
     }
+
 }

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
@@ -262,13 +262,6 @@ final class Protoc {
             }
             outputOption += javaOutputDirectory;
             command.add(outputOption);
-
-            // For now we assume all custom plugins produce Java output
-            for (final ProtocPlugin plugin : plugins) {
-                final File pluginExecutable = plugin.getPluginExecutableFile(pluginDirectory);
-                command.add("--plugin=protoc-gen-" + plugin.getId() + '=' + pluginExecutable);
-                command.add("--" + plugin.getId() + "_out=" + javaOutputDirectory);
-            }
         }
         if (cppOutputDirectory != null) {
             command.add("--cpp_out=" + cppOutputDirectory);
@@ -298,6 +291,16 @@ final class Protoc {
             }
             outputOption += customOutputDirectory;
             command.add(outputOption);
+        }
+        for (final ProtocPlugin plugin : plugins) {
+            final File pluginExecutable = new File(pluginDirectory, plugin.getPluginExecutableName());
+            command.add("--plugin=protoc-gen-" + plugin.getId() + '=' + pluginExecutable);
+            String pluginOutOption = "--" + plugin.getId() + "_out=";
+            if(plugin.getParameter() != null) {
+                pluginOutOption += plugin.getParameter() + ':';
+            }
+            pluginOutOption += plugin.getOutputDirectory();
+            command.add(pluginOutOption);
         }
         for (final File protoFile : protoFiles) {
             command.add(protoFile.toString());

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
@@ -17,6 +17,7 @@ package org.xolstice.maven.plugin.protobuf;
  */
 
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.Os;
 
 import java.io.File;
@@ -48,9 +49,13 @@ public class ProtocPlugin {
 
     private String version;
 
+    private String type = "jar";
+
     private String classifier;
 
     private String mainClass;
+
+    private String parameter;
 
     private String javaHome;
 
@@ -58,6 +63,11 @@ public class ProtocPlugin {
     // current JVM as the default. This property is only relevant on
     // Windows where we need to pick the right version of the WinRun4J executable.
     private String winJvmDataModel;
+
+    @Parameter(
+        required = false
+    )
+    private File outputDirectory;
 
     private List<String> args;
 
@@ -101,6 +111,13 @@ public class ProtocPlugin {
     }
 
     /**
+     * The type of the artifact (eg. 'exe' or 'jar').
+     *
+     * @return the plugin artifact type
+     */
+    public String getType() { return type; }
+
+    /**
      * Returns an optional classifier of the plugin's artifact for dependency resolution.
      *
      * @return the plugin's artifact classifier.
@@ -117,6 +134,13 @@ public class ProtocPlugin {
     public String getMainClass() {
         return mainClass;
     }
+
+    /**
+     * Returns the plugin's argument to be passed to protoc.
+     *
+     * @return protoc argument
+     */
+    public String getParameter() { return parameter; }
 
     /**
      * Returns optional command line arguments to pass to the {@code main()} method.
@@ -150,6 +174,14 @@ public class ProtocPlugin {
 
     public String getPluginName() {
         return "protoc-gen-" + id;
+    }
+
+    public void setOutputDirectory(File outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+
+    public File getOutputDirectory() {
+        return outputDirectory;
     }
 
     /**
@@ -217,16 +249,19 @@ public class ProtocPlugin {
     }
 
     /**
-     * Returns the generated plugin executable path.
+     * Returns the generated plugin executable name.
      *
-     * @param pluginDirectory directory where plugins will be created
-     * @return file handle for the plugin executable.
      */
-    public File getPluginExecutableFile(final File pluginDirectory) {
-        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            return new File(pluginDirectory, getPluginName() + ".exe");
+    public String getPluginExecutableName() {
+        if("jar".equalsIgnoreCase(type) && mainClass == null) {
+            //this is an uberjar plugin
+            return getPluginName() + ".jar";
         } else {
-            return new File(pluginDirectory, getPluginName());
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                return getPluginName() + ".exe";
+            } else {
+                return getPluginName();
+            }
         }
     }
 
@@ -237,8 +272,10 @@ public class ProtocPlugin {
                 ", groupId='" + groupId + '\'' +
                 ", artifactId='" + artifactId + '\'' +
                 ", version='" + version + '\'' +
+                ", type='" + type + '\'' +
                 ", classifier='" + classifier + '\'' +
                 ", mainClass='" + mainClass + '\'' +
+                ", parameter='" + parameter + '\'' +
                 ", javaHome='" + javaHome + '\'' +
                 ", winJvmDataModel='" + winJvmDataModel + '\'' +
                 ", args=" + args +


### PR DESCRIPTION
…toc.

The protobuf plugin does not allow for custom plugins to be supplied to
a single protoc that includes the main java stub generation. This ends
up being a problem for plugins that utilize features like protobuf's
extension point support, since they rely on protoc to supply info about
where it's main phase has emitted Java code.

Instead of relying on the compile-custom goal to execute a new, distinct
follow-on execution of protoc, allow for <plugin> elements in the
configuration of the main compile task to augment the arguments passed
to protoc. For example, after this commit, you can do the following

```xml
      <plugin>
        <groupId>org.xolstice.maven.plugins</groupId>
        <artifactId>protobuf-maven-plugin</artifactId>
        <version>0.7.0-SNAPSHOT</version>
        <configuration>
          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
          <protocPlugins>
            <plugin>
              <id>grpc-java</id>
              <groupId>io.grpc</groupId>
              <artifactId>protoc-gen-grpc-java</artifactId>
              <version>${grpc.version}</version>
              <type>exe</type>
              <classifier>${os.detected.classifier}</classifier>
            </plugin>
            <plugin>
              <id>kotlin</id>
              <groupId>com.github.marcoferrer.krotoplus</groupId>
              <artifactId>protoc-gen-kroto-plus</artifactId>
              <version>${kroto-plus.version}</version>
              <classifier>jvm8</classifier>
            </plugin>
          </protocPlugins>
        </configuration>
        <executions>
          <execution><goals><goal>compile</goal></goals></execution>
        </executions>
      </plugin>
```
With the above configuration, maven generates and executes a command line that looks like

```
protoc --java_out=... --plugin=protoc-gen-grpc-java --grpc-java_out=... --plugin=protoc-gen-kroto-plus --kroto-plus_out=...
```
which allows for plugins to have full access to the entire protoc
generation context.
