### PR TITLE
Support passing option to Java compiler (fix #64)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ install:
   # Download all dependencies that integration tests might need later
   # These include protoc and grpc plugin executables being referenced in toolchains.xml
   - cmd: mvnw.cmd -B -V -Dstyle.color=always -Djansi.passthrough=true dependency:go-offline -f src/it/dependencies/pom.xml -P protoc-3.4.0
-  - cmd: mvnw.cmd -B -V -Dstyle.color=always -Djansi.passthrough=true dependency:go-offline -f src/it/dependencies/pom.xml -P protoc-3.6.1
+  - cmd: mvnw.cmd -B -V -Dstyle.color=always -Djansi.passthrough=true dependency:go-offline -f src/it/dependencies/pom.xml -P protoc-3.11.1
   - cmd: mvnw.cmd -B -V -Dstyle.color=always -Djansi.passthrough=true dependency:go-offline -P run-its
 
 build_script:

--- a/.appveyor/toolchains.xml
+++ b/.appveyor/toolchains.xml
@@ -42,11 +42,11 @@
     <toolchain>
         <type>protobuf</type>
         <provides>
-            <version>3.6.1</version>
+            <version>3.11.1</version>
         </provides>
         <configuration>
             <protocExecutable>
-                C:/Users/appveyor/.m2/repository/com/google/protobuf/protoc/3.6.1/protoc-3.6.1-windows-x86_64.exe
+                C:/Users/appveyor/.m2/repository/com/google/protobuf/protoc/3.11.1/protoc-3.11.1-windows-x86_64.exe
             </protocExecutable>
         </configuration>
     </toolchain>

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ before_install:
 install:
   # Download all dependencies that integration tests might need later
   - ./mvnw -B -V -Dstyle.color=always dependency:go-offline -f src/it/dependencies/pom.xml -P protoc-3.4.0
-  - ./mvnw -B -V -Dstyle.color=always dependency:go-offline -f src/it/dependencies/pom.xml -P protoc-3.6.1
+  - ./mvnw -B -V -Dstyle.color=always dependency:go-offline -f src/it/dependencies/pom.xml -P protoc-3.11.1
   - ./mvnw -B -V -Dstyle.color=always dependency:go-offline -P run-its
 
 before_script:
   # These protoc executables were downloaded in the previous phase and are being referenced in toolchains.xml
   - chmod +x $HOME/.m2/repository/com/google/protobuf/protoc/3.4.0/protoc-3.4.0-linux-x86_64.exe
-  - chmod +x $HOME/.m2/repository/com/google/protobuf/protoc/3.6.1/protoc-3.6.1-linux-x86_64.exe
+  - chmod +x $HOME/.m2/repository/com/google/protobuf/protoc/3.11.1/protoc-3.11.1-linux-x86_64.exe
 
 script:
   # Finally, run the build with integration tests

--- a/.travis/toolchains.xml
+++ b/.travis/toolchains.xml
@@ -42,11 +42,11 @@
     <toolchain>
         <type>protobuf</type>
         <provides>
-            <version>3.6.1</version>
+            <version>3.11.1</version>
         </provides>
         <configuration>
             <protocExecutable>
-                /home/travis/.m2/repository/com/google/protobuf/protoc/3.6.1/protoc-3.6.1-linux-x86_64.exe
+                /home/travis/.m2/repository/com/google/protobuf/protoc/3.11.1/protoc-3.11.1-linux-x86_64.exe
             </protocExecutable>
         </configuration>
     </toolchain>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,9 @@
     <body>
 
         <release version="0.7.0" date="Pending" description="TBD">
+            <action dev="henryju" type="add" issue="64" due-to="Julien Henry (henryju)">
+                Support passing options to the Java compiler.
+            </action>
             <action dev="sergei-ivanov" type="update" issue="57" due-to="David Reichert (davidmreichert)">
                 Allowed more flexibility in specifying input proto files.
                 Versioned file extensions (e.g. .proto2, .proto3) can be used.

--- a/src/it/TEST-36/invoker.properties
+++ b/src/it/TEST-36/invoker.properties
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# An optional description for this build job to be included in the build reports.
+invoker.description = Verifies that Java generation works for lite runtime, using additional generator options
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean compile

--- a/src/it/TEST-36/pom.xml
+++ b/src/it/TEST-36/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.xolstice.maven.plugins.protobuf.its</groupId>
+        <artifactId>it-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>test-36</artifactId>
+    <version>1.0.0</version>
+
+    <name>Integration Test 36</name>
+    
+    <properties>
+      <protobufJavaArtifact>protobuf-javalite</protobufJavaArtifact>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <javaOptions>lite</javaOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <protocArtifact>
+                        com.google.protobuf:protoc:${protobufVersion}:exe:${os.detected.classifier}
+                    </protocArtifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/TEST-36/src/main/proto/test.proto
+++ b/src/it/TEST-36/src/main/proto/test.proto
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_package = "test";
+option java_outer_classname = "TestProtos";
+option optimize_for = SPEED;
+
+message TestMessage {
+  message NestedMessage {
+    int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  // Singular
+  int32 optional_int32    =  1;
+}

--- a/src/it/TEST-36/verify.groovy
+++ b/src/it/TEST-36/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+outputDirectory = new File(basedir, 'target/generated-sources/protobuf/java');
+assert outputDirectory.exists();
+assert outputDirectory.isDirectory();
+
+generatedJavaFile = new File(outputDirectory, 'test/TestProtos.java');
+assert generatedJavaFile.exists();
+assert generatedJavaFile.isFile();
+
+content = generatedJavaFile.text;
+assert content.contains('package test');
+assert content.contains('class Test');
+assert content.contains('class TestMessage');
+assert content.contains('com.google.protobuf.GeneratedMessageLite');
+
+return true;

--- a/src/it/dependencies/pom.xml
+++ b/src/it/dependencies/pom.xml
@@ -172,10 +172,10 @@
         </profile>
 
         <profile>
-            <id>protoc-3.6.1</id>
+            <id>protoc-3.11.1</id>
 
             <properties>
-                <protobufVersion>3.6.1</protobufVersion>
+                <protobufVersion>3.11.1</protobufVersion>
             </properties>
 
             <dependencies>

--- a/src/it/setup-it-parent/pom.xml
+++ b/src/it/setup-it-parent/pom.xml
@@ -41,7 +41,7 @@
 
         <mavenVersion>3.3.9</mavenVersion>
 
-        <protobufVersion>3.9.1</protobufVersion>
+        <protobufVersion>3.11.1</protobufVersion>
         <protobufJavaArtifact>protobuf-java</protobufJavaArtifact>
     </properties>
 

--- a/src/it/setup-it-parent/pom.xml
+++ b/src/it/setup-it-parent/pom.xml
@@ -41,7 +41,8 @@
 
         <mavenVersion>3.3.9</mavenVersion>
 
-        <protobufVersion>3.6.1</protobufVersion>
+        <protobufVersion>3.9.1</protobufVersion>
+        <protobufJavaArtifact>protobuf-java</protobufJavaArtifact>
     </properties>
 
     <build>
@@ -163,7 +164,7 @@
     <dependencies>
         <dependency>
             <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
+            <artifactId>${protobufJavaArtifact}</artifactId>
             <version>${protobufVersion}</version>
         </dependency>
         <!-- Test dependencies -->

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
@@ -256,7 +256,12 @@ final class Protoc {
             command.add("--proto_path=" + protoPathElement);
         }
         if (javaOutputDirectory != null) {
-            command.add("--java_out=" + javaOutputDirectory);
+            String outputOption = "--java_out=";
+            if (nativePluginParameter != null) {
+                outputOption += nativePluginParameter + ':';
+            }
+            outputOption += javaOutputDirectory;
+            command.add(outputOption);
 
             // For now we assume all custom plugins produce Java output
             for (final ProtocPlugin plugin : plugins) {

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocCompileMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocCompileMojo.java
@@ -47,13 +47,27 @@ public final class ProtocCompileMojo extends AbstractProtocCompileMojo {
             defaultValue = "${project.build.directory}/generated-sources/protobuf/java"
     )
     private File outputDirectory;
+    
+    
+    /**
+     * Additional comma-separated options to be passed to the Java generator.
+     * <b>Cannot</b> contain colon (<tt>:</tt>) symbols.
+     */
+    @Parameter(
+            required = false,
+            property = "javaOptions"
+    )
+    private String javaOptions;
 
     @Override
     protected void addProtocBuilderParameters(final Protoc.Builder protocBuilder) {
         super.addProtocBuilderParameters(protocBuilder);
+        if (javaOptions != null) {
+            protocBuilder.setNativePluginParameter(javaOptions);
+        }
         protocBuilder.setJavaOutputDirectory(getOutputDirectory());
     }
-
+    
     @Override
     protected File getOutputDirectory() {
         return outputDirectory;

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocCompileMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocCompileMojo.java
@@ -48,10 +48,10 @@ public final class ProtocCompileMojo extends AbstractProtocCompileMojo {
     )
     private File outputDirectory;
     
-    
     /**
      * Additional comma-separated options to be passed to the Java generator.
      * <b>Cannot</b> contain colon (<tt>:</tt>) symbols.
+     * @since 0.7.0
      */
     @Parameter(
             required = false,

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocTestCompileMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocTestCompileMojo.java
@@ -49,10 +49,24 @@ public final class ProtocTestCompileMojo extends AbstractProtocTestCompileMojo {
             defaultValue = "${project.build.directory}/generated-test-sources/protobuf/java"
     )
     private File outputDirectory;
+    
+    /**
+     * Additional comma-separated options to be passed to the Java generator.
+     * <b>Cannot</b> contain colon (<tt>:</tt>) symbols.
+     * @since 0.7.0
+     */
+    @Parameter(
+            required = false,
+            property = "javaOptions"
+    )
+    private String javaOptions;
 
     @Override
     protected void addProtocBuilderParameters(final Protoc.Builder protocBuilder) {
         super.addProtocBuilderParameters(protocBuilder);
+        if (javaOptions != null) {
+          protocBuilder.setNativePluginParameter(javaOptions);
+        }
         protocBuilder.setJavaOutputDirectory(getOutputDirectory());
         // We need to add project output directory to the protobuf import paths,
         // in case test protobuf definitions extend or depend on production ones

--- a/src/site/apt/examples/protobuf-dependencies.apt.vm
+++ b/src/site/apt/examples/protobuf-dependencies.apt.vm
@@ -75,7 +75,7 @@ import "it/project1/test1.proto";
 <project>
   ...
   <properties>
-    <protobufVersion>3.6.1</protobufVersion>
+    <protobufVersion>3.11.1</protobufVersion>
     <grpcVersion>1.7.0</grpcVersion>
   </properties>
   ...


### PR DESCRIPTION
**Applicable Issues**
Fixes #64 

**Description**
Like for the JavaScript compiler, allow to pass additional options to the Java compiler. Especially useful for generating `lite` code.
