### PR TITLE
Support for plugin options in java plugins

### DIFF
--- a/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/Protoc.java
@@ -267,6 +267,7 @@ final class Protoc {
             for (final ProtocPlugin plugin : plugins) {
                 final File pluginExecutable = plugin.getPluginExecutableFile(pluginDirectory);
                 command.add("--plugin=protoc-gen-" + plugin.getId() + '=' + pluginExecutable);
+                command.add("--" + plugin.getId() + "_opt=\"" + plugin.getOptionsAsString() + "\"");
                 command.add("--" + plugin.getId() + "_out=" + javaOutputDirectory);
             }
         }

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/ProtocPlugin.java
@@ -60,6 +60,8 @@ public class ProtocPlugin {
     private String winJvmDataModel;
 
     private List<String> args;
+    
+    private List<String> options;
 
     private List<String> jvmArgs;
 
@@ -125,6 +127,22 @@ public class ProtocPlugin {
      */
     public List<String> getArgs() {
         return args != null ? args : emptyList();
+    }
+
+    /**
+     * Returns optional plugin options to be passed to protoc
+     * @return a list of plugin options
+     */
+    public List<String> getOptions() {
+        return options != null ? options : emptyList();
+    }
+
+    /**
+     * Returns list of plugin options as string
+     * @return
+     */
+    public String getOptionsAsString() {
+        return String.join(" ", getOptions());
     }
 
     /**
@@ -242,6 +260,7 @@ public class ProtocPlugin {
                 ", javaHome='" + javaHome + '\'' +
                 ", winJvmDataModel='" + winJvmDataModel + '\'' +
                 ", args=" + args +
+                ", options=" + options +
                 ", jvmArgs=" + jvmArgs +
                 '}';
     }

--- a/src/site/apt/examples/protoc-plugin.apt.vm
+++ b/src/site/apt/examples/protoc-plugin.apt.vm
@@ -98,6 +98,8 @@ Using Custom Protoc Plugins
     are '32' or '64'.
 
   * <<<args>>> - (optional) argument to pass to the <<<main>>> method
+  
+  * <<<options>>> - (optional) options to be passed to the plugin <<<id>>>
 
   * <<<jvmArgs>>> - (optional) JVM arguments
 


### PR DESCRIPTION
**Description**
`<protocPlugin>` has `args`, `jvmArgs`, but does not have `pluginOptions`. Plugin options are needed to pass any plugin specific options to the plugin. They are passed to the plugin as part of the `CodeGeneratorRequest` that goes into the plugin via stdin. These options can be retrieved with `CodeGeneratorRequest.getParameter()` within the plugin.

This PR adds support for pluginOptions. They are passed to protoc as `--<pluginId>_opt=<options>`