### PR TITLE
Add properties to Mojo parameters checkStaleness and staleMillis

### DIFF
--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -333,6 +333,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
      */
     @Parameter(
             required = false,
+            property = "protoc.staleMillis",
             defaultValue = "0"
     )
     private long staleMillis;
@@ -346,6 +347,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
      */
     @Parameter(
             required = false,
+            property = "protoc.checkStaleness",
             defaultValue = "false"
     )
     private boolean checkStaleness;

--- a/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
+++ b/src/main/java/org/xolstice/maven/plugin/protobuf/AbstractProtocMojo.java
@@ -330,6 +330,8 @@ abstract class AbstractProtocMojo extends AbstractMojo {
      * <p>This parameter is only used when {@link #checkStaleness} parameter is set to {@code true}.
      *
      * <p>If the project is built on NFS it's recommended to set this parameter to {@code 10000}.
+     *
+     * @since 0.6.1
      */
     @Parameter(
             required = false,
@@ -344,6 +346,7 @@ abstract class AbstractProtocMojo extends AbstractMojo {
      * timestamps of source protobuf definitions vs. generated sources.
      *
      * @see #staleMillis
+     * @since 0.6.1
      */
     @Parameter(
             required = false,


### PR DESCRIPTION
**Description**

This PR adds `property` definitions to the `AbstractProtocMojo` fields `checkStaleness` and `staleMillis` for use from the maven CLI (`mvn`). The need for this change came about while trying to improve the maven build times for the backend at my work, and I noticed I couldn't change the `checkStaleness` configuration property, as I might in other maven plugins (ex: `mvn package -DskipTests -Djacoco.skip=true`). I hope this adds some additional value to an already fantastic project. 

I'm relatively unfamiliar with how Mojo/Maven plugins work, so if I've made a mistake please let me know and I will correct it.

Additinally, I wasn't sure what version to use when adding `@since <version>` to the doc comments for the parameters I updated, so I used the latest version.