### PR TITLE
Support proto sources from artifacts

### DIFF
--- a/src/it/TEST-28/pom.xml
+++ b/src/it/TEST-28/pom.xml
@@ -90,5 +90,10 @@
             <artifactId>grpc-stub</artifactId>
             <version>${grpcVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/it/TEST-38/invoker.properties
+++ b/src/it/TEST-38/invoker.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# An optional description for this build job to be included in the build reports.
+invoker.description = \
+  Verifies that protoc location is picked up from 'protobuf' tool chain, \
+  and proto compilation completes successfully.
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean compile

--- a/src/it/TEST-38/pom.xml
+++ b/src/it/TEST-38/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.xolstice.maven.plugins.protobuf.its</groupId>
+        <artifactId>it-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>test-1</artifactId>
+    <version>1.0.0</version>
+
+    <name>Integration Test 1</name>
+
+    <properties>
+        <protobufVersion>[3.4.0,3.5.0)</protobufVersion>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>protobuf-toolchain</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                        <configuration>
+                            <toolchains>
+                                <protobuf>
+                                    <version>${protobufVersion}</version>
+                                </protobuf>
+                            </toolchains>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceArtifacts>
+                                <sourceArtifact>org.xolstice.maven.plugins.protobuf.its:proto-publish:1.0.0</sourceArtifact>
+                            </sourceArtifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/TEST-38/src/main/proto/test2.proto
+++ b/src/it/TEST-38/src/main/proto/test2.proto
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_package = "test2";
+option java_outer_classname = "TestProtos2";
+option optimize_for = SPEED;
+
+message TestMessage2 {
+  message NestedMessage {
+    int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  // Singular
+  int32 optional_int32    =  1;
+}

--- a/src/it/TEST-38/verify.groovy
+++ b/src/it/TEST-38/verify.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+outputDirectory = new File(basedir, 'target/generated-sources/protobuf/java');
+assert outputDirectory.exists();
+assert outputDirectory.isDirectory();
+
+// check classes generated from the given artifact protos
+generatedJavaFile = new File(outputDirectory, 'test/TestProtos.java');
+assert generatedJavaFile.exists();
+assert generatedJavaFile.isFile();
+
+content = generatedJavaFile.text;
+assert content.contains('package test');
+assert content.contains('class Test');
+assert content.contains('class TestMessage');
+
+// check classes generated from the local protos (src/main/proto)
+generatedJavaFile = new File(outputDirectory, 'test2/TestProtos2.java');
+assert generatedJavaFile.exists();
+assert generatedJavaFile.isFile();
+
+content = generatedJavaFile.text;
+assert content.contains('package test2');
+assert content.contains('class TestMessage2');
+
+return true;

--- a/src/it/setup-proto-publish/invoker.properties
+++ b/src/it/setup-proto-publish/invoker.properties
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# An optional description for this build job to be included in the build reports.
+invoker.description = \
+  Publishes test proto as a jar to local maven repository.
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals = clean install

--- a/src/it/setup-proto-publish/pom.xml
+++ b/src/it/setup-proto-publish/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.xolstice.maven.plugins.protobuf.its</groupId>
+        <artifactId>it-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>proto-publish</artifactId>
+    <version>1.0.0</version>
+
+    <name>Publish protos into repo</name>
+
+    <properties>
+        <protobufVersion>[3.4.0,3.5.0)</protobufVersion>
+    </properties>
+</project>

--- a/src/it/setup-proto-publish/src/main/resources/test.proto
+++ b/src/it/setup-proto-publish/src/main/resources/test.proto
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2016 Maven Protocol Buffers Plugin Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+option java_package = "test";
+option java_outer_classname = "TestProtos";
+option optimize_for = SPEED;
+
+message TestMessage {
+  message NestedMessage {
+    int32 bb = 1;
+  }
+
+  enum NestedEnum {
+    FOO = 0;
+    BAR = 1;
+    BAZ = 2;
+  }
+
+  // Singular
+  int32 optional_int32    =  1;
+}


### PR DESCRIPTION
**Description**
This adds support for pulling source proto files from artifacts in addition to the local module. This enables to pull a published protos from maven central and use them to generate sources.
